### PR TITLE
ループ処理追加

### DIFF
--- a/Muse_prot/app/src/main/java/com/shun/prototype/Sound_Front.java
+++ b/Muse_prot/app/src/main/java/com/shun/prototype/Sound_Front.java
@@ -162,6 +162,8 @@ public class Sound_Front extends Activity{
 				mediaPlayer.setDataSource(fis.getFD());
 				// 待機
 				mediaPlayer.prepare();
+				// ループ再生の設定
+				mediaPlayer.setLooping(true);
 			}
 			catch( IOException e)
 			{


### PR DESCRIPTION
optionからの設定はbpmのみ
optionから継続再生していると、GrafhicViewがお亡くなりになる。
